### PR TITLE
Fix missing microprofile dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,9 +66,8 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>org.eclipse.microprofile</groupId>
-            <artifactId>microprofile</artifactId>
-            <type>pom</type>
+            <groupId>org.eclipse.microprofile.config</groupId>
+            <artifactId>microprofile-config-api</artifactId>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>


### PR DESCRIPTION
The structure of the microprofile maven bill-of-materials pom.xml
changed from version 4.0 so that the needed profiles need to be
explicitly stated.